### PR TITLE
Null type support

### DIFF
--- a/tests/integrated/types/null.test.ts
+++ b/tests/integrated/types/null.test.ts
@@ -1,0 +1,59 @@
+import type { Assert } from "../../../dist/index";
+import { call } from "../../utils";
+import { expect } from "chai";
+
+type Obj = {
+    a: number | null;
+};
+
+type ObjNullMember = {
+    a: null;
+};
+
+describe("Nullable object members", () => {
+
+    function testObjNull(c: Assert<Obj>) {
+        return c;
+    }
+
+    it("Not throw when not null is set", () => {
+        expect(call(testObjNull, { a: 1 })).to.not.throw();
+    });
+
+    it("Throw when nullable member is not of the correct type", () => {
+        expect(call(testObjNull, {a: "abc"})).to.throw();
+    });
+
+    it("Not throw when null is set", () => {
+        expect(call(testObjNull, { a: null })).to.not.throw();
+    });
+
+    it("Throw when undefined is set", () => {
+        expect(call(testObjNull, { a: undefined })).to.throw();
+    });
+
+    it("Throw when member is not defined", () => {
+        expect(call(testObjNull, {})).to.throw();
+    });
+
+    function testOnlyNullMember(c: Assert<ObjNullMember>) {
+        return c;
+    }
+
+    it("Throw when not null is set to only-null member", () => {
+        expect(call(testOnlyNullMember, { a: 1 })).to.throw();
+    });
+
+    it("Not throw when null is set to only-null member", () => {
+        expect(call(testOnlyNullMember, { a: null })).to.not.throw();
+    });
+
+    it("Throw when undefined is set to only-null member", () => {
+        expect(call(testOnlyNullMember, { a: undefined })).to.throw();
+    });
+
+    it("Throw when mandatory only-null member is not defined", () => {
+        expect(call(testOnlyNullMember, {})).to.throw();
+    });
+
+});

--- a/tests/integrated/types/object.test.ts
+++ b/tests/integrated/types/object.test.ts
@@ -5,36 +5,45 @@ import { expect } from "chai";
 interface Test {
     a: string,
     b?: number
+    c?: number | null
 }
 
 describe("Object", () => {
     describe("Assert", () => {
-        function test(a: Assert<Test & { c: Array<string> }>) {
+        function test(a: Assert<Test & { d: Array<string> }>) {
             return a;
         }
 
         it("Throw when one of the properties has the wrong type", () => {
             expect(call(test, {
                 a: "ABC",
-                c: 123
-            })).to.throw("Expected a.c to be string[].");
+                d: 123
+            })).to.throw("Expected a.d to be string[].");
             expect(call(test, {
                 a: "ABC",
-                b: "adc",
-                c: 123
+                b: "abc",
+                d: 123
             })).to.throw("Expected a.b to be number.");
             expect(call(test, {
                 a: "ABC",
                 b: 123,
-                c: [1]
-            })).to.throw("Expected a.c[0] to be string.");
+                c: "abc",
+                d: [1]
+            })).to.throw("Expected a.c to be number | null.");
+            expect(call(test, {
+                a: "ABC",
+                b: 123,
+                c: 456,
+                d: [1]
+            })).to.throw("Expected a.d[0] to be string.");
         });
     
         it("Not throw when all of the values are of the same type", () => {
             expect(call(test, {
                 a: "ABC",
                 b: 123,
-                c: ["Hello"]
+                c: null,
+                d: ["Hello"]
             })).to.not.throw();
         });
 

--- a/tests/integrated/types/optional.test.ts
+++ b/tests/integrated/types/optional.test.ts
@@ -2,7 +2,7 @@ import type { Assert } from "../../../dist/index";
 import { call } from "../../utils";
 import { expect } from "chai";
 
-describe("Optional / nullable parameters", () => {
+describe("Optional parameters", () => {
     function test(c: Assert<number>, a?: Assert<string>, b?: Assert<[string, string, number?]>) {
         return [a, b, c];
     }

--- a/tests/snapshots/artifacts/types_null.test.js
+++ b/tests/snapshots/artifacts/types_null.test.js
@@ -1,0 +1,47 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = require("../../utils");
+const chai_1 = require("chai");
+describe("Nullable object members", () => {
+    function testObjNull(c) {
+        if (typeof c !== "object")
+            throw new Error("Expected c to be Obj.");
+        if (c["a"] !== null && typeof c["a"] !== "number")
+            throw new Error("Expected c.a to be number | null.");
+        return c;
+    }
+    it("Not throw when not null is set", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testObjNull, { a: 1 })).to.not.throw();
+    });
+    it("Throw when nullable member is not of the correct type", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testObjNull, { a: "abc" })).to.throw();
+    });
+    it("Not throw when null is set", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testObjNull, { a: null })).to.not.throw();
+    });
+    it("Throw when undefined is set", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testObjNull, { a: undefined })).to.throw();
+    });
+    it("Throw when member is not defined", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testObjNull, {})).to.throw();
+    });
+    function testOnlyNullMember(c) {
+        if (typeof c !== "object")
+            throw new Error("Expected c to be ObjNullMember.");
+        if (c["a"] !== null)
+            throw new Error("Expected c.a to be null.");
+        return c;
+    }
+    it("Throw when not null is set to only-null member", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testOnlyNullMember, { a: 1 })).to.throw();
+    });
+    it("Not throw when null is set to only-null member", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testOnlyNullMember, { a: null })).to.not.throw();
+    });
+    it("Throw when undefined is set to only-null member", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testOnlyNullMember, { a: undefined })).to.throw();
+    });
+    it("Throw when mandatory only-null member is not defined", () => {
+        (0, chai_1.expect)((0, utils_1.call)(testOnlyNullMember, {})).to.throw();
+    });
+});

--- a/tests/snapshots/artifacts/types_object.test.js
+++ b/tests/snapshots/artifacts/types_object.test.js
@@ -6,41 +6,51 @@ describe("Object", () => {
     describe("Assert", () => {
         function test(a) {
             if (typeof a !== "object")
-                throw new Error("Expected a to be Test & { c: string[]; }.");
+                throw new Error("Expected a to be Test & { d: string[]; }.");
             if (typeof a["a"] !== "string")
                 throw new Error("Expected a.a to be string.");
             if ("b" in a && typeof a["b"] !== "number")
                 throw new Error("Expected a.b to be number.");
-            if (!(a["c"] instanceof Array))
-                throw new Error("Expected a.c to be string[].");
-            for (let i_1 = 0; i_1 < a["c"].length; i_1++) {
-                const x_1 = a["c"][i_1];
+            if ("c" in a && (a["c"] !== null && typeof a["c"] !== "number"))
+                throw new Error("Expected a.c to be number | null.");
+            if (!(a["d"] instanceof Array))
+                throw new Error("Expected a.d to be string[].");
+            for (let i_1 = 0; i_1 < a["d"].length; i_1++) {
+                const x_1 = a["d"][i_1];
                 if (typeof x_1 !== "string")
-                    throw new Error("Expected " + ("a.c[" + i_1 + "]") + " to be string.");
+                    throw new Error("Expected " + ("a.d[" + i_1 + "]") + " to be string.");
             }
             return a;
         }
         it("Throw when one of the properties has the wrong type", () => {
             (0, chai_1.expect)((0, utils_1.call)(test, {
                 a: "ABC",
-                c: 123
-            })).to.throw("Expected a.c to be string[].");
+                d: 123
+            })).to.throw("Expected a.d to be string[].");
             (0, chai_1.expect)((0, utils_1.call)(test, {
                 a: "ABC",
-                b: "adc",
-                c: 123
+                b: "abc",
+                d: 123
             })).to.throw("Expected a.b to be number.");
             (0, chai_1.expect)((0, utils_1.call)(test, {
                 a: "ABC",
                 b: 123,
-                c: [1]
-            })).to.throw("Expected a.c[0] to be string.");
+                c: "abc",
+                d: [1]
+            })).to.throw("Expected a.c to be number | null.");
+            (0, chai_1.expect)((0, utils_1.call)(test, {
+                a: "ABC",
+                b: 123,
+                c: 456,
+                d: [1]
+            })).to.throw("Expected a.d[0] to be string.");
         });
         it("Not throw when all of the values are of the same type", () => {
             (0, chai_1.expect)((0, utils_1.call)(test, {
                 a: "ABC",
                 b: 123,
-                c: ["Hello"]
+                c: null,
+                d: ["Hello"]
             })).to.not.throw();
         });
     });

--- a/tests/snapshots/artifacts/types_optional.test.js
+++ b/tests/snapshots/artifacts/types_optional.test.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../utils");
 const chai_1 = require("chai");
-describe("Optional / nullable parameters", () => {
+describe("Optional parameters", () => {
     function test(c, a, b) {
         if (typeof c !== "number")
             throw new Error("Expected c to be number.");

--- a/tests/snapshots/artifacts/utilities_exact_props.test.js
+++ b/tests/snapshots/artifacts/utilities_exact_props.test.js
@@ -50,7 +50,7 @@ describe("Exact Props", () => {
         });
         function test3(a) {
             if (typeof a !== "object")
-                throw new Error("Expected a to be { a: string; b: ExactProps<{ c: number; }, false>; }.");
+                throw new Error("Expected a to be { a: string; b: ExactProps<{ c: number; }>; }.");
             if (typeof a["a"] !== "string")
                 throw new Error("Expected a.a to be string.");
             if (typeof a["b"] !== "object")

--- a/tests/snapshots/index.ts
+++ b/tests/snapshots/index.ts
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs";
 import readline from "readline";
 import { diffLines } from "diff";
+import { EOL } from "os";
 
 const rl = readline.createInterface(process.stdin, process.stdout);
 
@@ -27,11 +28,11 @@ if (!fs.existsSync(artifactsPath)) fs.mkdirSync(artifactsPath);
     const wrongful: Array<string> = [];
     for (const [fileName, dirName, passedDirs] of eachFile(integrated, "")) {
         const newFilePath = path.join(dirName, fileName);
-        const newFile = fs.readFileSync(path.join(dirName, fileName), "utf-8");
+        const newFile = normalizeEOL(fs.readFileSync(path.join(dirName, fileName), "utf-8"));
         const targetFilePath = path.join(artifactsPath, passedDirs.replace("/", "_") + fileName);
         if (!fs.existsSync(targetFilePath)) fs.writeFileSync(targetFilePath, newFile);
         else {
-            const oldFile = fs.readFileSync(targetFilePath, "utf-8");
+            const oldFile = normalizeEOL(fs.readFileSync(targetFilePath, "utf-8"));
             if (oldFile === newFile) continue;
             const diffs = diffLines(oldFile, newFile);
     
@@ -80,4 +81,9 @@ async function askYesOrNo(q: string) : Promise<boolean> {
         if (answer === "y") return true;
         else if (answer === "n") return false;
     }
+}
+
+function normalizeEOL(input: string): string {
+    const lines = input.split(/\r\n|\r|\n/);
+    return lines.join(EOL);
 }


### PR DESCRIPTION
Currently ts-runtime-checks does not differentiate an optional object member from an object member which can be `null`.

For example: `{a: 2}` would be valid with `Assert<{a: number; b: number | null}>` which should not be the case as b is `undefined`.

This PR aims at supporting the above example.

It does not, however, adds support for the same construct in a parameter.

